### PR TITLE
repro duplicate symbols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "spawns_panic_repro_ffi"
+name = "spawns_panic_repro_ffi_v1"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+ "spawns",
+ "tokio",
+]
+
+[[package]]
+name = "spawns_panic_repro_ffi_v2"
 version = "0.1.0"
 dependencies = [
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,10 @@
-[package]
-name = "spawns_panic_repro_ffi"
+[workspace]
+members = ["ffi_v1", "ffi_v2"]
+resolver = "2"
+
+[profile.release]
+lto = "fat"
+
+[workspace.package]
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[lib]
-name = "test_ffi"
-crate-type = ["staticlib"] # for .a static lib
-
-
-[dependencies]
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
-spawns = { version = "0.2.4", features = ["tokio"] }
-
-[build-dependencies]
-cbindgen = "0.29.0"

--- a/bindings_v1.h
+++ b/bindings_v1.h
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void v1_repro(void);

--- a/bindings_v2.h
+++ b/bindings_v2.h
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void v2_repro(void);

--- a/ffi_v1/Cargo.toml
+++ b/ffi_v1/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spawns_panic_repro_ffi_v1"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "ffi_v1"
+crate-type = ["staticlib"]
+
+[dependencies]
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
+spawns = { version = "0.2.4", features = ["tokio"] }
+
+[build-dependencies]
+cbindgen = "0.29.0"

--- a/ffi_v1/bindings_v1.h
+++ b/ffi_v1/bindings_v1.h
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void v1_repro(void);

--- a/ffi_v1/build.rs
+++ b/ffi_v1/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut config: cbindgen::Config = Default::default();
+    config.language = cbindgen::Language::C;
+    // config.export.prefix = Some("v1_".to_string());
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file("bindings_v1.h");
+}

--- a/ffi_v1/src/lib.rs
+++ b/ffi_v1/src/lib.rs
@@ -1,0 +1,16 @@
+#[no_mangle]
+pub unsafe extern "C" fn v1_repro() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let _guard = rt.enter();
+    rt.block_on(connect());
+}
+
+async fn connect() {
+    let h = spawns::spawn(async move {
+        println!("async spawn from v1");
+    });
+    h.await.unwrap();
+}

--- a/ffi_v2/Cargo.toml
+++ b/ffi_v2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spawns_panic_repro_ffi_v2"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+name = "ffi_v2"
+crate-type = ["staticlib"]
+
+[dependencies]
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros"] }
+spawns = { version = "0.2.4", features = ["tokio"] }
+
+[build-dependencies]
+cbindgen = "0.29.0"

--- a/ffi_v2/bindings_v2.h
+++ b/ffi_v2/bindings_v2.h
@@ -1,0 +1,6 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void v2_repro(void);

--- a/ffi_v2/build.rs
+++ b/ffi_v2/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut config: cbindgen::Config = Default::default();
+    config.language = cbindgen::Language::C;
+    // config.export.prefix = Some("v2_".to_string());
+
+    cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file("bindings_v2.h");
+}

--- a/ffi_v2/src/lib.rs
+++ b/ffi_v2/src/lib.rs
@@ -1,0 +1,16 @@
+#[no_mangle]
+pub unsafe extern "C" fn v2_repro() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let _guard = rt.enter();
+    rt.block_on(connect());
+}
+
+async fn connect() {
+    let h = spawns::spawn(async move {
+        println!("async spawn from v2");
+    });
+    h.await.unwrap();
+}

--- a/main.c
+++ b/main.c
@@ -1,6 +1,12 @@
-#include "bindings.h"
+#include <stdio.h>
+#include "bindings_v1.h"
+#include "bindings_v2.h"
 
 int main() {
-  repro();
+  printf("Calling v1_repro()...\n");
+  v1_repro();
+  printf("Calling v2_repro()...\n");
+  v2_repro();
+  printf("Done!\n");
   return 0;
 }

--- a/repro.sh
+++ b/repro.sh
@@ -1,22 +1,6 @@
 #!/bin/bash
 
-# When multiple static libraries with LTO enabled share dependencies,
-# duplicate symbols cause linker errors. The solution is to either:
-# 1. Disable LTO in the workspace (allows linking without special flags)
-# 2. Build libraries without LTO (can be linked together)
-# 3. Use special linker flags to suppress errors
-#
-# We use approach #3: Keep LTO enabled (lto = "fat" in Cargo.toml) for
-# maximum optimization. Try multiple linker flag combinations:
-
-# Option 1: Allow common symbols to use dylib resolution
-LINKER_FLAGS="-Wl,-commons,use_dylibs"
-
-# Option 2: Suppress all warnings (if option 1 doesn't work)
-# LINKER_FLAGS="-Wl,-w"
-
-# Option 3: Force flat namespace (deprecated, last resort)
-# LINKER_FLAGS="-Wl,-flat_namespace -Wl,-undefined,suppress"
+LINKER_FLAGS="-Wl,--allow-multiple-definition"
 
 echo "--- Running DEBUG build ---"
 cargo build --manifest-path=ffi_v1/Cargo.toml

--- a/repro.sh
+++ b/repro.sh
@@ -1,12 +1,35 @@
 #!/bin/bash
+
+# When multiple static libraries with LTO enabled share dependencies,
+# duplicate symbols cause linker errors. The solution is to either:
+# 1. Disable LTO in the workspace (allows linking without special flags)
+# 2. Build libraries without LTO (can be linked together)
+# 3. Use special linker flags to suppress errors
+#
+# We use approach #3: Keep LTO enabled (lto = "fat" in Cargo.toml) for
+# maximum optimization. Try multiple linker flag combinations:
+
+# Option 1: Allow common symbols to use dylib resolution
+LINKER_FLAGS="-Wl,-commons,use_dylibs"
+
+# Option 2: Suppress all warnings (if option 1 doesn't work)
+# LINKER_FLAGS="-Wl,-w"
+
+# Option 3: Force flat namespace (deprecated, last resort)
+# LINKER_FLAGS="-Wl,-flat_namespace -Wl,-undefined,suppress"
+
 echo "--- Running DEBUG build ---"
-cargo build
-cp target/debug/libtest_ffi.a ./
-clang main.c -L$(pwd) -ltest_ffi -lm
+cargo build --manifest-path=ffi_v1/Cargo.toml
+cargo build --manifest-path=ffi_v2/Cargo.toml
+cp target/debug/libffi_v1.a ./
+cp target/debug/libffi_v2.a ./
+clang main.c -L$(pwd) -lffi_v1 -lffi_v2 -lm $LINKER_FLAGS
 ./a.out
 echo ""
-echo "--- Running RELEASE build -"
-cargo build --release
-cp target/release/libtest_ffi.a ./
-clang main.c -L$(pwd) -ltest_ffi -lm
+echo "--- Running RELEASE build ---"
+cargo build --release --manifest-path=ffi_v1/Cargo.toml
+cargo build --release --manifest-path=ffi_v2/Cargo.toml
+cp target/release/libffi_v1.a ./
+cp target/release/libffi_v2.a ./
+clang main.c -L$(pwd) -lffi_v1 -lffi_v2 -lm $LINKER_FLAGS
 ./a.out


### PR DESCRIPTION
Demonstrates panic in the spawns crate when imported twice through the FFI, this is caused by duplicate symbols issue.

The repro only works on linux (flags to ignore duplicate symbol linker complaints are ignored on macOS).

Run `./repro.sh` to get the issue
Sample output:

```
--- Running DEBUG build ---
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s
Calling v1_repro()...
async spawn from v1
Calling v2_repro()...
async spawn from v2
Done!

--- Running RELEASE build ---
    Finished `release` profile [optimized] target(s) in 0.07s
    Finished `release` profile [optimized] target(s) in 0.07s
Calling v1_repro()...

thread '<unnamed>' panicked at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/linkme-0.3.33/src/distributed_slice.rs:258:13:
duplicate #[distributed_slice] with name "COMPATS"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5, aborting
./repro.sh: line 19: 2741447 Aborted                 (core dumped) ./a.out
```